### PR TITLE
Add babel-core to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "Timothy Jones",
   "license": "GPL-3.0+",
   "devDependencies": {
+    "babel-core": "^6.23.1",
     "babel-loader": "^6.2.4",
     "babel-polyfill": "^6.9.0",
     "babel-preset-es2015": "^6.9.0",


### PR DESCRIPTION
@zmthy @dougeasterly 
Hey Guys, I tried to install your awesome project and I just got an error from webpack/babel, that it cannot find the `babel-core` package, so I think, it is missing from the `package.json`. This pull request add this extra package to the `package.json`. After that everything worked like a charm. Amazing tool. Great project. Keep up the good work! ;)